### PR TITLE
Update to a current Ubuntu version and important pygopherd patches

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:19.10
 
 MAINTAINER kalemeow <kizzale@gmail.com>
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,15 @@
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 
-MAINTAINER kalemeow <kizzale@gmail.com>
+MAINTAINER dana-ross <dana@danaross.dev>
 
-RUN apt-get update && apt-get install -y pygopherd
-
+RUN apt-get update && apt install -y python curl logrotate patch
+RUN curl -L -o ./python-simpletal.deb http://mirrors.kernel.org/ubuntu/pool/universe/s/simpletal/python-simpletal_4.1-9_all.deb && dpkg -i ./python-simpletal.deb
+RUN curl -L -o pygopherd.deb http://mirrors.kernel.org/ubuntu/pool/universe/p/pygopherd/pygopherd_2.0.18.5_all.deb && dpkg -i pygopherd.deb
 ADD conf/pygopherd.conf /etc/pygopherd/pygopherd.conf
 
 EXPOSE 70
+
+RUN curl -O https://github.com/jgoerzen/pygopherd/commit/50c01600afbb99be1f6aba63ae3a007404a0bbc4.patch && patch /usr/lib/python2.7/dist-packages/pygopherd/handlers/UMN.py 50c01600afbb99be1f6aba63ae3a007404a0bbc4.patch
+RUN curl -O https://github.com/jgoerzen/pygopherd/commit/926b185da25c0f303c90dc2cf78f3d24bef9f7a6.patch && patch /usr/lib/python2.7/dist-packages/pygopherd/handlers/gophermap.py 926b185da25c0f303c90dc2cf78f3d24bef9f7a6.patch
 
 CMD pygopherd

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:20.04
 
-MAINTAINER dana-ross <dana@danaross.dev>
+MAINTAINER kalemeow <kizzale@gmail.com>
 
 RUN apt-get update && apt install -y python curl logrotate patch
 RUN curl -L -o ./python-simpletal.deb http://mirrors.kernel.org/ubuntu/pool/universe/s/simpletal/python-simpletal_4.1-9_all.deb && dpkg -i ./python-simpletal.deb


### PR DESCRIPTION
To get pygopherd running on a current Ubuntu install, I needed to have my container running Ubuntu 19.10 (Eoan Ermine).

This PR explicitly has Docker pull `:19.10` instead of `:latest`.